### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/rockspecs/document-1.0.0-1.rockspec
+++ b/rockspecs/document-1.0.0-1.rockspec
@@ -2,7 +2,7 @@ package = 'document'
 version = '1.0.0-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/document.git';
+    url    = 'git+https://github.com/tarantool/document.git';
     tag = '1.0.0';
 }
 

--- a/rockspecs/document-1.0.1-1.rockspec
+++ b/rockspecs/document-1.0.1-1.rockspec
@@ -2,7 +2,7 @@ package = 'document'
 version = '1.0.1-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/document.git';
+    url    = 'git+https://github.com/tarantool/document.git';
     tag = '1.0.1';
 }
 

--- a/rockspecs/document-scm-1.rockspec
+++ b/rockspecs/document-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'document'
 version = 'scm-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/document.git';
+    url    = 'git+https://github.com/tarantool/document.git';
     branch = 'master';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587