### PR TITLE
Fix usage of Tarantool internal API for retrieving schema version

### DIFF
--- a/document.lua
+++ b/document.lua
@@ -153,9 +153,11 @@ end
 
 local function get_schema(space)
     if space.connection == nil then
-        if local_schema_id ~= box.internal.schema_version() then
+        -- If Tarantool public API for schema version is not available, fallback to unreliable internal API.
+        local current_schema_id = box.info.schema_version or box.internal.schema_version()
+        if local_schema_id ~= current_schema_id then
             local_schema_cache = {}
-            local_schema_id = box.internal.schema_version()
+            local_schema_id = current_schema_id
         end
 
         local cached = local_schema_cache[space.id]


### PR DESCRIPTION
tarantool/tarantool#7904 exports schema version to public API and Lua: start using it, when available, instead of unreliable internal API.

Closes #9